### PR TITLE
Legg på annotering som starter en span når en river faktisk skal lese…

### DIFF
--- a/rapids-and-rivers/build.gradle.kts
+++ b/rapids-and-rivers/build.gradle.kts
@@ -1,6 +1,7 @@
 val jacksonVersion: String by project
 val testcontainersVersion: String by project
 val awaitilityVersion = "4.2.2"
+val otelVersion = "2.9.0"
 
 dependencies {
     api(project(":kafka"))
@@ -8,6 +9,8 @@ dependencies {
 
     api("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
+
+    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:$otelVersion")
 
     testImplementation(project(":rapids-and-rivers-test"))
     testImplementation("org.testcontainers:kafka:$testcontainersVersion")

--- a/rapids-and-rivers/src/main/kotlin/com/github/navikt/tbd_libs/rapids_and_rivers/River.kt
+++ b/rapids-and-rivers/src/main/kotlin/com/github/navikt/tbd_libs/rapids_and_rivers/River.kt
@@ -8,6 +8,8 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
+import io.opentelemetry.instrumentation.annotations.SpanAttribute
+import io.opentelemetry.instrumentation.annotations.WithSpan
 
 class River(rapidsConnection: RapidsConnection, private val randomIdGenerator: RandomIdGenerator = RandomIdGenerator.Default) : RapidsConnection.MessageListener {
     private val validations = mutableListOf<PacketValidation>()
@@ -60,7 +62,8 @@ class River(rapidsConnection: RapidsConnection, private val randomIdGenerator: R
         }
     }
 
-    private fun notifyPacketListener(metrics: MeterRegistry, eventName: String, packetListener: PacketListener, packet: JsonMessage, context: MessageContext) {
+    @WithSpan
+    private fun notifyPacketListener(metrics: MeterRegistry, @SpanAttribute("eventName") eventName: String, packetListener: PacketListener, packet: JsonMessage, context: MessageContext) {
         onMessageCounter(metrics, context.rapidName(), packetListener.name(), "ok", eventName)
         val timer = Timer.start(metrics)
         packetListener.onPacket(packet, context)


### PR DESCRIPTION
… en melding

Teorien er at det gjør det enklere å filtrere bort traces hvor meldingen ikke skal behandles på grunn av valideringsregelene til riveren.