### PR TITLE
Vent på ACK fra alle Kafka noder topicen krever

### DIFF
--- a/kafka/src/main/kotlin/com/github/navikt/tbd_libs/kafka/AivenConfig.kt
+++ b/kafka/src/main/kotlin/com/github/navikt/tbd_libs/kafka/AivenConfig.kt
@@ -34,7 +34,7 @@ class AivenConfig(
 
     override fun producerConfig(properties: Properties) = Properties().apply {
         putAll(kafkaBaseConfig())
-        put(ProducerConfig.ACKS_CONFIG, "1")
+        put(ProducerConfig.ACKS_CONFIG, "all")
         put(ProducerConfig.LINGER_MS_CONFIG, "0")
         put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1")
         putAll(properties)


### PR DESCRIPTION
Når `ACKS_CONFIG` er satt til `1` venter vi kun på svar fra noden som er master. Om det oppstår gnufs før master har syncet data til slaver så kan vi miste meldinger.

https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#acks

Settes den til `all` så vil Kafka vente på så mange noder som verdien av `min.insync.replicas` for topicet. For *veldig* mange i Nav så er den satt til `1` så det blir uansett ikke noe endring i oppførsel.

De som ønsker kan redigere config for sine topics og øke den til en verdi de mener gir god nok garanti.

https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#min-insync-replicas