### PR TITLE
Lag en enkel content-negotation for scraping

### DIFF
--- a/naisful-app/src/main/kotlin/com/github/navikt/tbd_libs/naisful/NaisfulApp.kt
+++ b/naisful-app/src/main/kotlin/com/github/navikt/tbd_libs/naisful/NaisfulApp.kt
@@ -261,7 +261,12 @@ fun Application.standardApiModule(
         }
 
         get(naisEndpoints.metricsEndpoint) {
-            call.respond(meterRegistry.scrape())
+             call.request.acceptItems().firstOrNull()?.let {
+                val contentType = ContentType.parse(it.value)
+                val metrics = meterRegistry.scrape(it.value)
+
+                call.respondText(metrics, contentType)
+            } ?: call.respond(HttpStatusCode.NotAcceptable, "Supported types: application/openmetrics-text and text/plain")
         }
     }
 }


### PR DESCRIPTION
Det gjør det mulig for scraperen å hente metrikker i `application/openmetrics-text` som støtter exemplars.