### PR TITLE
Logg exceptions og OTel-spor ved feil i publishRecordsInBulk

### DIFF
--- a/rapids-and-rivers/src/main/kotlin/com/github/navikt/tbd_libs/rapids_and_rivers/KafkaRapid.kt
+++ b/rapids-and-rivers/src/main/kotlin/com/github/navikt/tbd_libs/rapids_and_rivers/KafkaRapid.kt
@@ -9,6 +9,8 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.SentMessage
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.instrumentation.annotations.WithSpan
 import java.time.Duration
 import java.time.LocalDateTime
 import java.util.*
@@ -69,6 +71,7 @@ class KafkaRapid(
         return rapidTopic
     }
 
+    @WithSpan
     private fun publishRecordsInBulk(messages: List<OutgoingMessage>): Pair<List<SentMessage>, List<FailedMessage>> {
         val results = messages
             .map { it to producer.send(it.producerRecord(rapidTopic)) }
@@ -77,6 +80,12 @@ class KafkaRapid(
                     val metadata = future.get()
                     Pair(SentMessage(index, record, metadata.partition(), metadata.offset()), null)
                 } catch (err: Exception) {
+                    Span.current().recordException(err)
+                    log.error(
+                        "failed to produce message index=$index of ${messages.size}, key=${record.key}: {}",
+                        err.message,
+                        err
+                    )
                     Pair(null, FailedMessage(index, record, err))
                 }
             }
@@ -91,7 +100,7 @@ class KafkaRapid(
 
         if (failed.isNotEmpty()) {
             /* handle all failed messages as a fatal error */
-            log.error("Failed to produce ${failed.size} message(s): invoking shutdown!")
+            log.error("Failed to produce ${failed.size} of ${messages.size} message(s): invoking shutdown!")
             stop()
         }
 


### PR DESCRIPTION
## Hva
Individuelle exceptions fra feilede Kafka-publiseringer i `KafkaRapid.publishRecordsInBulk` ble fanget i `FailedMessage`, men aldri logget eller sporet noe sted - kun et aggregert antall uten stacktrace ble logget. Siden returverdien fra `publish()` ikke inspiseres noe sted i praksis, forsvant de reelle feilene sporløst.

## Endring
- `@WithSpan` på `publishRecordsInBulk` for OTel-sporing
- `Span.current().recordException(err)` per feilet melding - nødvendig fordi exceptionen fanges og ikke propagerer ut av metoden, så OTel sin automatiske instrumentering (som kun reagerer på kastede exceptions) fanger den ikke
- `log.error` med stacktrace per feilet melding, i tillegg til den eksisterende aggregerte loggen

Ingen endring i signatur eller atferd.